### PR TITLE
BUG: loss of inline fuse slice under rare conditions

### DIFF
--- a/tests/GslCore.Tests/AssemblyTestSupport.fs
+++ b/tests/GslCore.Tests/AssemblyTestSupport.fs
@@ -318,6 +318,16 @@ let linkerDoug =
         true // amplified
         Breed.B_LINKER
 
+let linkerEmma =
+    makeSimpleSlice
+        (Dna "ATCGATTAGATTAGCTACTGTGGTCCAAA")
+        "linkerEmma"
+        SliceType.LINKER
+        EmptyPragmas
+        false // from approx
+        false // to approx
+        true // amplified
+        Breed.B_LINKER
 let placeholder =
     makeSimpleSlice
         (Dna "")

--- a/tests/GslCore.Tests/TestMapRyseLinkers.fs
+++ b/tests/GslCore.Tests/TestMapRyseLinkers.fs
@@ -11,7 +11,7 @@ open Amyris.ErrorHandling
 type TestMapRyseLinkers() =
 
     /// Enable for detailed (very detailed) output from mapRyseLinkers - useful for debugging test cases
-    let verbose = true
+   let verbose = false
 
     do
         // initialize pragmas
@@ -175,3 +175,12 @@ type TestMapRyseLinkers() =
             ([linkerAlice; linkerBob;linkerCharlie; linkerDoug],[])
             [uFoo;  pBaz ;fuse; uFoo (* no fuse c.f inlineFusedExample2 *); shortInline; dFoo ; shortInline ; oBar2 ;fuse ; tShaz ; shortInlineWithRabitStart; dFoo]
             [linkerAlice ; uFoo; linkerBob; pBaz ; uFoo; shortInline; dFoo ; shortInline ; oBar2 ;tShaz ; linkerCharlie; shortInlineWithRabitStart; dFoo ; linkerDoug]
+
+    [<Test>]
+    member __.``internalInlineMarkhell2Case``()  =
+        runOne "internalInlineMarkhell2Case"
+            false
+            ([linkerAlice ; linkerBob ; linkerCharlie ; linkerDoug ; linkerEmma],[])
+            [ uFoo ;pBaz ; fuse; oBar; shortInlineWithRabitStart; oBar2 ; shortInlineWithRabitEnd; tShaz ]
+            [ linkerAlice ; uFoo ; linkerBob ;pBaz ; oBar; linkerCharlie ; shortInlineWithRabitStart; oBar2 ; shortInlineWithRabitEnd; linkerDoug; tShaz ;linkerEmma ]
+

--- a/tests/GslCore.Tests/TestMapRyseLinkers.fs
+++ b/tests/GslCore.Tests/TestMapRyseLinkers.fs
@@ -11,7 +11,7 @@ open Amyris.ErrorHandling
 type TestMapRyseLinkers() =
 
     /// Enable for detailed (very detailed) output from mapRyseLinkers - useful for debugging test cases
-   let verbose = false
+    let verbose = false
 
     do
         // initialize pragmas

--- a/tests/GslCore.Tests/TestProcAssembly.fs
+++ b/tests/GslCore.Tests/TestProcAssembly.fs
@@ -34,7 +34,7 @@ module SharedSliceTesting =
 type TestProcAssembly() =
 
     // enable for detailed (very detailed) output from procAssembly. Useful for debugging test cases
-    let verbose = false
+    let verbose = true
 
     do
         // initialize pragmas
@@ -292,3 +292,11 @@ type TestProcAssembly() =
             [ linkerAlice; uFoo ; dFoo ; shortInlineWithRabitEnd ; linkerCharlie]
             "DGDGSD"
             [ linkerAlice; uFoo ; fuse ;  dFoo; shortInlineWithRabitEnd ; linkerCharlie]
+
+    [<Test>]
+    member __.``internalInlineMarkhell2Case``()  =
+        runOne "internalInlineMarkhell2Case"
+            [ linkerAlice ; uFoo ; linkerBob ;pBaz ; oBar; linkerCharlie ; shortInlineWithRabitStart; oBar2 ; shortInlineWithRabitEnd; linkerDoug; tShaz ;linkerEmma ]
+            "DGDGDGDSGSDGD"
+            [ linkerAlice ; uFoo ; linkerBob ;pBaz ; fuse ; oBar; linkerCharlie ; shortInlineWithRabitStart; oBar2 ; shortInlineWithRabitEnd; linkerDoug; tShaz ;linkerEmma ]
+


### PR DESCRIPTION
This was a similar bug to some previous cases where prev was used instead of slicesOut in procAssembly, resulting in revision of previous slices, and dropping a fuse slice.  Good test coverage and a fix.