### PR TITLE
Add global tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ paket.local
 .idea
 .tool
 **/AssemblyInfo.fs
+.ionide/

--- a/src/GslCore/PragmaTypes.fs
+++ b/src/GslCore/PragmaTypes.fs
@@ -448,7 +448,8 @@ type Pragma = {
     member x.name = x.definition.name
     member x.isTransient =
         match x.definition.scope with
-        | BlockOnly(Persistent) | BlockOrPart(Persistent) -> false
+        | BlockOnly(Persistent) | BlockOrPart(Persistent)
+        | BlockOnly(PersistentCumulative) | BlockOrPart(PersistentCumulative) -> false
         | _ -> true
     /// Does this pragma announce the availability of an extension capability?
     member x.SetsCapability =

--- a/src/GslCore/PragmaTypes.fs
+++ b/src/GslCore/PragmaTypes.fs
@@ -23,7 +23,7 @@ type PragmaArgShape =
 
 type PragmaValidationResult = Result<unit,string>
 
-type PragmaPersistence = | Persistent | Transient | TransientCumulative
+type PragmaPersistence = | Persistent | PersistentCumulative | Transient | TransientCumulative
 
 ///<summary>
 /// Pragmas are scoped within a GSL document.  Some pragmas
@@ -586,6 +586,8 @@ type PragmaCollection = PragmaCollection of Map<string,Pragma>
     member x.Add(p:Pragma) =
         PragmaCollection (
             match p.definition.scope with
+            | BlockOnly(PersistentCumulative)
+            | BlockOrPart(PersistentCumulative)
             | BlockOnly(TransientCumulative)
             | BlockOrPart(TransientCumulative) ->
                 match x.pmap.TryFind(p.name) with

--- a/src/GslCore/TaggingProvider.fs
+++ b/src/GslCore/TaggingProvider.fs
@@ -37,14 +37,17 @@ let validateTag args =
     >>= (fun _ -> ok ())
 
 let tagPragmaDef =
-    {name = "tag"; argShape = AtLeast 1; scope = BlockOnly(TransientCumulative);
-     desc = "tag assemblies with terms from a namespace.";
-     invertsTo = None; validate = validateTag} 
+    { name = "tag"; argShape = AtLeast 1; scope = BlockOnly(TransientCumulative);
+      desc = "tag assemblies with terms from a namespace.";
+      invertsTo = None; validate = validateTag } 
 
 let gTagPragmaDef =
-    { name = "gtag"; argShape = AtLeast 1; scope = BlockOnly(PersistentCumulative);
-      desc = "global tag assemblies with terms from a namespace.";
-      invertsTo = None; validate = validateTag }  
+    { name = "gtag"
+      argShape = AtLeast 1
+      scope = BlockOnly(PersistentCumulative);
+      desc = "global tag assemblies with tags from a namespace."
+      invertsTo = None
+      validate = validateTag }  
 
 /// Take previous #tag namespace:tagvalue  lines and fold into the assembly structure
 let foldInTags (cmdlineTags : AssemblyTag list) (_at : ATContext) (a : DnaAssembly) =

--- a/src/GslCore/TaggingProvider.fs
+++ b/src/GslCore/TaggingProvider.fs
@@ -37,9 +37,12 @@ let validateTag args =
     >>= (fun _ -> ok ())
 
 let tagPragmaDef =
-    { name = "tag"; argShape = AtLeast 1; scope = BlockOnly(TransientCumulative);
-      desc = "tag assemblies with terms from a namespace.";
-      invertsTo = None; validate = validateTag } 
+    { name = "tag"
+      argShape = AtLeast 1
+      scope = BlockOnly(TransientCumulative)
+      desc = "tag assemblies with terms from a namespace."
+      invertsTo = None
+      validate = validateTag } 
 
 let gTagPragmaDef =
     { name = "gtag"

--- a/src/GslCore/TaggingProvider.fs
+++ b/src/GslCore/TaggingProvider.fs
@@ -41,12 +41,18 @@ let tagPragmaDef =
      desc = "tag assemblies with terms from a namespace.";
      invertsTo = None; validate = validateTag} 
 
+let gTagPragmaDef =
+    { name = "gtag"; argShape = AtLeast 1; scope = BlockOnly(PersistentCumulative);
+      desc = "global tag assemblies with terms from a namespace.";
+      invertsTo = None; validate = validateTag }  
+
 /// Take previous #tag namespace:tagvalue  lines and fold into the assembly structure
-let foldInTags (cmdlineTags:AssemblyTag list) (_at:ATContext) (a:DnaAssembly) =
-    match a.pragmas.TryFind("tag") with
-    | None -> ok a
-    | Some pragma ->
-        match parseTags pragma.args with
+let foldInTags (cmdlineTags : AssemblyTag list) (_at : ATContext) (a : DnaAssembly) =
+    // gtag is global tag, tag is dna assembly tag
+    match List.collect (fun pragma -> pragma.args) ([ a.pragmas.TryFind("tag") ; a.pragmas.TryFind("gtag") ] |> List.choose id) with
+    | [] -> ok a
+    | args ->
+        match parseTags args with
         | Ok(newTags,_) ->
             ok {a with tags = cmdlineTags@newTags |> List.fold (fun tags tag -> tags.Add(tag)) a.tags}
         | Bad msg -> fail {msg = String.Join(";",msg) ; kind = ATError ; assembly = a ; stackTrace = None ; fromException = None}
@@ -84,7 +90,7 @@ let createTaggingPlugin extraArgProcessor =
       [{name = None;
         description = None;
         behavior = AssemblyTransform({cmdlineTags = []; processExtraArgs = extraArgProcessor})}]
-    providesPragmas = [tagPragmaDef];
+    providesPragmas = [tagPragmaDef ; gTagPragmaDef];
     providesCapas = []}
 
 let taggingPlugin = createTaggingPlugin (fun _ x -> x)

--- a/tests/GslCore.Tests/TestTagging.fs
+++ b/tests/GslCore.Tests/TestTagging.fs
@@ -105,6 +105,18 @@ uADH1; dADH1
 uADH1; dADH1
 """ 
 
+    /// one global tag, two scoped tag
+    let threeTagsOneGlobalTwoScoped = """#refgenome cenpk
+#platform stitch
+#gtag flavor:vanilla
+
+#tag temp:hot
+uADH1; dADH1
+
+#tag condiment:ketchup
+uADH2; dADH2
+""" 
+
     let runAndExtractTags code =
             code
             |> compileOne
@@ -261,13 +273,41 @@ uADH1; dADH1
         Assert.AreEqual(1, results.Length)
 
         match results with
-        | [ _assembly1, pragmas1 ] ->
-            // should be one pragma on this assembly with two parts
-            match pragmas1 with
-            | [p] ->
-                // should match the entered text - with both pragmas together
-                Assert.AreEqual([ "flavor:vanilla" ; "temp:hot" ], p.args)
+        | [ _assembly1, pragmas ] ->
+            // should be two pragmas on this assembly
+            match pragmas with
+            | [p1 ; p2] ->
+                // should have global tag and scoped tag
+                Assert.AreEqual([ "flavor:vanilla" ], p1.args)
+                Assert.AreEqual([ "temp:hot" ], p2.args)
 
             | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
 
         | x -> failwithf "bad assembly pattern %A in OneGlobalOneScopedTag" x
+
+    [<Test>]
+    member __.OneGlobalTwoScopedTag() =
+        let results = threeTagsOneGlobalTwoScoped |> runAndExtractTags
+
+        // should be two assemblies
+        Assert.AreEqual(2, results.Length)
+
+        match results with
+        | [_assembly1, pragmas1 ; _assembly2, pragmas2] ->
+            // should be two pragmas on assembly 1
+            match pragmas1 with
+            | [p1 ; p2] ->
+                // should have global tag and scoped tag
+                Assert.AreEqual([ "flavor:vanilla" ], p1.args)
+                Assert.AreEqual([ "temp:hot" ], p2.args)
+            | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
+
+            // should be two pragmas on assembly 2
+            match pragmas2 with
+            | [p1 ; p2] ->
+                // should have global tag and scoped tag
+                Assert.AreEqual([ "flavor:vanilla" ], p1.args)
+                Assert.AreEqual([ "condiment:ketchup" ], p2.args)
+            | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
+
+        | x -> failwithf "bad assembly pattern %A in OneGlobalTwoScopedTag" x


### PR DESCRIPTION
Added `#gtag` as a pragma.

`gtag` stands for global tag and has the ability to declare tags globally in a GSL document. It is a persisting pragma.

## How does it work?

Input:
```
#gtag flavor:vanilla
#tag condiment:ketchup
```

Output:

```
<tag nspace="condiment" tag="ketchup" />
<tag nspace="flavor" tag="vanilla" />
```