### PR TITLE
FEA: added deterministic to the built in arguments

### DIFF
--- a/src/GslCore/CommandConfig.fs
+++ b/src/GslCore/CommandConfig.fs
@@ -51,39 +51,49 @@ let libCmdArg =
         {name = "lib"; param = ["directory"]; alias = [];
          desc = "directory in which genome definitions reside\nDefault: GSL_LIB var, or 'lib' in current directory"}
      proc = fun p opts -> {opts with libDir = smashSlash p.[0]}}
+    
+let deterministicCmdArg =
+    let processParameters (_parameters: string list) (parsedOptions: ParsedOptions): ParsedOptions =
+        { parsedOptions with isDeterministic = true }
+    { CmdLineArg.spec =
+        { CmdLineArgSpec.name = "deterministic"
+          param = [ ]
+          alias = []
+          desc = "Produce deterministic output (= if rerun with same input then will produce identical output)" }
+      proc = processParameters }
+    
 /// Define all GSLC command line arguments here.
 /// An argument consists of its name, the names of its parameters, a description,
 /// and a function that takes a list of passed parameters and an options record
 /// and returns a modified options record.
 let builtinCmdLineArgs =
     [
-
         {spec=
             {name = "reflist" ; param = [] ; alias = [];
             desc = "list available reference genomes"}
-         proc = fun _ opts -> {opts with refList = true}} ;
+         proc = fun _ opts -> {opts with refList = true}}
 
         {spec=
             {name = "refdump" ; param = ["refname"] ; alias = [];
             desc = "dump available loci in reference genome"}
-         proc = fun p opts -> {opts with refDump = Some (p.[0])}} ;
+         proc = fun p opts -> {opts with refDump = Some (p.[0])}}
 
         {spec=
             {name = "step"; param = []; alias = [];
              desc = "expand GSL just one round, and emit intermediate GSL"}
-         proc = fun _ opts -> {opts with iter = false}};
+         proc = fun _ opts -> {opts with iter = false}}
 
         {spec=
             {name = "verbose"; param = []; alias = [];
              desc = "print debugging info"}
-         proc = fun _ opts -> {opts with verbose = true} };
+         proc = fun _ opts -> {opts with verbose = true} }
 
         {spec=
             {name = "version"; param = []; alias = [];
              desc = "print version information"}
          proc = fun _ opts ->
             printfn "GSL compiler version %s" version
-            opts};
+            opts}
 
         {spec=
             {name = "helpPragmas"; param = []; alias = [];
@@ -94,34 +104,36 @@ let builtinCmdLineArgs =
         {spec=
             {name = "quiet"; param = []; alias = [];
             desc = "suppress any non-essential output"}
-         proc = fun _ opts -> {opts with quiet = true} };
+         proc = fun _ opts -> {opts with quiet = true} }
 
         {spec=
             {name = "noprimers"; param = []; alias = [];
              desc = "do not attempt to generate primers"}
-         proc = fun _ opts -> {opts with noPrimers = true} };
+         proc = fun _ opts -> {opts with noPrimers = true} }
 
-        libCmdArg;
+        libCmdArg
 
         {spec=
             {name = "serial"; param = []; alias = [];
              desc = "don't run parallel operations, useful for debugging"}
-         proc = fun _ opts -> {opts with doParallel = false} };
+         proc = fun _ opts -> {opts with doParallel = false} }
 
         {spec=
             {name = "lextest"; param = []; alias = ["tokentest"; "tokenize"];
              desc = "for debugging only, show stream of parsed tokens from input file"}
-         proc = fun _ opts -> {opts with lexOnly = true} };
+         proc = fun _ opts -> {opts with lexOnly = true} }
 
         {spec=
             {name = "only_phase1"; param = []; alias = [];
              desc = "expand GSL just through the phase 1 pipeline, and emit intermediate GSL"}
-         proc = fun _ opts -> {opts with onlyPhase1 = true}};
+         proc = fun _ opts -> {opts with onlyPhase1 = true}}
 
         {spec=
             {name = "plugins"; param = []; alias = [];
              desc = "List all plugins installed in this build of the compiler."}
-         proc = fun _ opts -> {opts with listPlugins = true}};
+         proc = fun _ opts -> {opts with listPlugins = true}}
+        
+        deterministicCmdArg
 
       
     ]
@@ -165,18 +177,18 @@ let usageText (args: CollectedCommandLineArgs) =
     Seq.append ["Usage:  gscl [args] input.gsl"] argLines
     |> String.concat "\n"
 
-let defaultOpts:ParsedOptions =
-   {quiet = false;
-    libDir = libRoot;
-    refStrain = "cenpk";
-    iter = true;
-    onlyPhase1 = false;
-    doParallel = true;
-    verbose = false;
-    noPrimers = false;
-    lexOnly = false
-    refList = false
-    refDump = None
-    listPlugins = false
-    doHelpPragmas = false
-    }
+let defaultOpts: ParsedOptions =
+   { quiet = false
+     libDir = libRoot
+     refStrain = "cenpk"
+     iter = true
+     onlyPhase1 = false
+     doParallel = true
+     verbose = false
+     noPrimers = false
+     lexOnly = false
+     refList = false
+     refDump = None
+     listPlugins = false
+     doHelpPragmas = false
+     isDeterministic = false }

--- a/src/GslCore/CommandConfig.fs
+++ b/src/GslCore/CommandConfig.fs
@@ -5,8 +5,8 @@ open commonTypes
 open pragmaTypes
 open Amyris.Bio.utils
 
-let v = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version
-let version = sprintf "%d.%d.%d" v.Major v.Minor v.Build
+let informalVersion = AssemblyVersionInformation.AssemblyInformationalVersion // git hash
+let version = AssemblyVersionInformation.AssemblyVersion
 
 let libRoot =
     match Environment.GetEnvironmentVariable("GSL_LIB") with
@@ -92,7 +92,7 @@ let builtinCmdLineArgs =
             {name = "version"; param = []; alias = [];
              desc = "print version information"}
          proc = fun _ opts ->
-            printfn "GSL compiler version %s" version
+            printfn "GSL core compiler version %s (%s)" version informalVersion
             opts}
 
         {spec=

--- a/src/GslCore/CommonTypes.fs
+++ b/src/GslCore/CommonTypes.fs
@@ -14,20 +14,20 @@ type SequenceLibrary = Map<string, Dna>
 
 /// Instructions gleaned from command line
 type ParsedOptions =
-   {quiet: bool;
-    refStrain: string;
-    libDir: string;
-    iter: bool;
-    onlyPhase1: bool;
-    doParallel: bool;
-    verbose: bool;
-    noPrimers: bool;
-    lexOnly: bool;
-    refList : bool;
-    refDump : string option;
-    listPlugins: bool;
-    doHelpPragmas : bool
-    }
+   { quiet: bool
+     refStrain: string 
+     libDir: string 
+     iter: bool 
+     onlyPhase1: bool
+     doParallel: bool
+     verbose: bool
+     noPrimers: bool
+     lexOnly: bool
+     refList : bool
+     refDump : string option
+     listPlugins: bool
+     doHelpPragmas : bool
+     isDeterministic: bool }
 
 type DNAIntervalType = ANNEAL | RYSELINKER | AMP | SANDWICH
 type DNAInterval = {il:int; ir:int; iType:DNAIntervalType}

--- a/src/GslCore/GslCore.fsproj
+++ b/src/GslCore/GslCore.fsproj
@@ -13,6 +13,7 @@
         <FsLexYacc Include="GslParser.fsy"> </FsLexYacc>
   -->
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <FsYacc Include=".\GslParser.fsy">
       <OtherFlags>--module GslParser -o GslParser.fs</OtherFlags>
     </FsYacc>
@@ -66,7 +67,6 @@
     <Compile Include="GslcProcess.fs" />
     <Compile Include="SeamlessPlugin.fs" />
     <Compile Include="Gslc.fs" />
-    <Compile Include="AssemblyInfo.fs" />
   </ItemGroup>
   <Import Project="..\..\packages\FsLexYacc\build\FsLexYacc.targets" />
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/GslCore/Gslc.fs
+++ b/src/GslCore/Gslc.fs
@@ -144,7 +144,7 @@ let configureGslc unconfiguredPlugins argv =
             let s = configure true legalCmdLineArgs unconfiguredPlugins args
 
             if not s.opts.quiet && not s.opts.refList && s.opts.refDump.IsNone then
-                printf "// GSL compiler version %s\n" version
+                printf "// GSL core compiler version %s (%s)\n" version informalVersion
 
             if s.opts.listPlugins then
                 let pluginDescs = s.plugins |> List.map (fun p -> p.Info) |> String.concat "\n\n"

--- a/src/GslCore/TaggingProvider.fs
+++ b/src/GslCore/TaggingProvider.fs
@@ -56,11 +56,14 @@ let gTagPragmaDef =
 let foldInTags (cmdlineTags : AssemblyTag list) (_at : ATContext) (a : DnaAssembly) =
     // gtag is global tag, tag is dna assembly tag
     match List.collect (fun pragma -> pragma.args) ([ a.pragmas.TryFind("tag") ; a.pragmas.TryFind("gtag") ] |> List.choose id) with
-    | [] -> ok a
+    | [] ->
+        let newTags = cmdlineTags |> Set.ofList |> Set.union a.tags
+        ok { a with tags = newTags }
     | args ->
         match parseTags args with
         | Ok(newTags,_) ->
-            ok {a with tags = cmdlineTags@newTags |> List.fold (fun tags tag -> tags.Add(tag)) a.tags}
+            let newTags = (cmdlineTags @ newTags) |> Set.ofList |> Set.union a.tags 
+            ok { a with tags = newTags }
         | Bad msg -> fail {msg = String.Join(";",msg) ; kind = ATError ; assembly = a ; stackTrace = None ; fromException = None}
         
 type TaggingProvider = {

--- a/tests/GslCore.Tests/TestDnaAssemblyTransformation.fs
+++ b/tests/GslCore.Tests/TestDnaAssemblyTransformation.fs
@@ -10,9 +10,7 @@ open pragmaTypes
 open Amyris.Dna
 open constants
 
-[<TestFixture>]
-type Test() = 
-
+module AssemblyTestBase =
     let emptyAssembly: Assembly = {
         parts = []
         name = None
@@ -63,8 +61,10 @@ type Test() =
         materializedFrom = emptyAssembly
         tags=Set.empty
         topology = Linear
-    }
+    }    
 
+[<TestFixture>]
+type Test() = 
     let runTest assembly expectedSource =
         let transformed =
             cleanLongSlices () assembly
@@ -81,27 +81,29 @@ type Test() =
 
     [<Test>]
     member x.TestLongSliceUsesDnaSrc() =
-        let sliceNoSource = testSlice EmptyPragmas
-        let assemblyNoSource = testAssembly sliceNoSource EmptyPragmas
+        let sliceNoSource = AssemblyTestBase.testSlice EmptyPragmas
+        let assemblyNoSource = AssemblyTestBase.testAssembly sliceNoSource EmptyPragmas
 
         runTest assemblyNoSource "synthetic"
 
         let refGenomePragmas = EmptyPragmas.Add("refgenome", "foogenome") |> returnOrFail
 
-        let assemblyHasRefGenome = testAssembly sliceNoSource refGenomePragmas
+        let assemblyHasRefGenome = AssemblyTestBase.testAssembly sliceNoSource refGenomePragmas
 
         runTest assemblyHasRefGenome "foogenome"
 
         let sliceWithSource =
             EmptyPragmas.Add("dnasrc", "foosource")
             |> returnOrFail
-            |> testSlice
+            |> AssemblyTestBase.testSlice
 
-        let assemblyHasSource = testAssembly sliceWithSource EmptyPragmas
+        let assemblyHasSource = AssemblyTestBase.testAssembly sliceWithSource EmptyPragmas
 
         runTest assemblyHasSource "foosource"
 
-        let assemblyHasSourceAndRef = testAssembly sliceWithSource refGenomePragmas
+        let assemblyHasSourceAndRef = AssemblyTestBase.testAssembly sliceWithSource refGenomePragmas
 
         // #dnasrc should take precedence over refgenome if both are present
         runTest assemblyHasSourceAndRef "foosource"
+
+    

--- a/tests/GslCore.Tests/TestMapRyseLinkers.fs
+++ b/tests/GslCore.Tests/TestMapRyseLinkers.fs
@@ -38,7 +38,8 @@ type TestMapRyseLinkers() =
                                      refList = false
                                      refDump = None
                                      listPlugins = false
-                                     doHelpPragmas = false }
+                                     doHelpPragmas = false
+                                     isDeterministic = false }
 
         let leftLinkers,rightLinkers = linkersIn
         let linkers = [for l in leftLinkers@rightLinkers -> l.sliceName , { RYSELinker.name = l.sliceName ; dna = l.dna }] |> Map.ofList


### PR DESCRIPTION
This PR adds a new option to the built in cmdline args: `deterministic`

It is meant to be a hint to the core compiler or plugins to strive to produce a deterministic output: if the compiler is rerun with exactly the same input will produce identical output. For instance, this is useful when plugins stamp a timestamp into an output file making comparison in testing harder.