### PR TITLE
BUG: primer trimming for empty linkers was missing lower primer lengt…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.4.57 - Jul 30th 2021
+* Bug fix for trimLinkerTail array out of bounds error
+
 #### 0.4.56 - Mar 15th 2021
 
 * Demetrix production release

--- a/src/GslCore/PrimerCreation.fs
+++ b/src/GslCore/PrimerCreation.fs
@@ -872,8 +872,8 @@ let trimLinkerTailBody (dp:DesignParams) (p:Primer) =
             {p with body=p.body.[..bLen-1]; tail = p.tail.[p.tail.Length-tLen..]}
         else
             // Someone needs to lose a basepair
-            if bLen = dp.pp.minLength then find bLen (tLen-1)
-            elif tLen = dp.pp.minLength then find (bLen-1) tLen
+            if bLen <= dp.pp.minLength then find bLen (tLen-1)
+            elif tLen <= dp.pp.minLength then find (bLen-1) tLen
             else
                 let bLen' = bLen - 1
                 let tLen' = tLen - 1


### PR DESCRIPTION
Bug fix for array out of bounds linker trimming error