### PR TITLE
22/06/bug inline amp pragmas

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 #### 0.4.60 - June 13th 2022
-* Enhancement to allow #inline to change regular sequences to inline
+* Enhancement to allow #inline to change regular sequences to inline, and convert short <30bp regular sequences to inline
+* Added error state if #inline and #amp are used together
 
 #### 0.4.59 - Apr 5th 2022
 * Maintenance release - upgrading to .NET6 and updating dependencies

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.4.60 - June 13th 2022
+* Enhancement to allow #inline to change regular sequences to inline
+
 #### 0.4.59 - Apr 5th 2022
 * Maintenance release - upgrading to .NET6 and updating dependencies
 

--- a/src/GslCore/GslcProcess.fs
+++ b/src/GslCore/GslcProcess.fs
@@ -156,8 +156,8 @@ let cleanShortSlicesInPartsList (p:pragmaTypes.PragmaCollection) (l:DNASlice lis
                         match p.TryGetOne("refgenome") with
                         | None -> "synthetic"
                         | Some(x) -> x
-                // add in an amp tag on this guy too, since we are now comitting to
-                // not placing it inline using primers
+                // add in an inline tag on this guy too, since we are now comitting to
+                // not making it as an amplicon
                 pragmas = match s.pragmas.TryFind("inline") with
                             | Some _ -> s.pragmas // already there
                             | None ->
@@ -170,8 +170,8 @@ let cleanShortSlicesInPartsList (p:pragmaTypes.PragmaCollection) (l:DNASlice lis
             }
         else s)
 
-/// Promote long slices to regular rabits to avoid trying to build
-/// impossibly long things with oligos.
+/// Demote short slices to inline rabits to build in oligos 
+/// rather than PCR
 let cleanShortSlices _ (a:DnaAssembly) =
     ok {a with dnaParts = cleanShortSlicesInPartsList a.pragmas a.dnaParts}
 

--- a/src/GslCore/GslcProcess.fs
+++ b/src/GslCore/GslcProcess.fs
@@ -129,6 +129,9 @@ let cleanLongSlicesInPartsList (p:pragmaTypes.PragmaCollection) (l:DNASlice list
                                     // exn if necessary
                                     failwithf "%s" (String.Join(";",messages))
             }
+        else if (s.pragmas.ContainsKey("amp") && s.pragmas.ContainsKey("inline"))
+        then
+            failwithf "ERROR: Part %s has incompatible pragmas #amp and #inline. Please pick one." s.sliceName
         else s)
 
 /// Promote long slices to regular rabits to avoid trying to build

--- a/tests/GslCore.Tests/AssemblyTestSupport.fs
+++ b/tests/GslCore.Tests/AssemblyTestSupport.fs
@@ -143,6 +143,20 @@ let tShaz =
         true // to approx
         true // amplified
         Breed.B_TERMINATOR
+        
+let oSmall =
+    makeSimpleSlice
+        (Dna "TACTGACTGAGTCTGACTGACG")
+        "oSmall"
+        SliceType.REGULAR
+        EmptyPragmas
+        false
+        false
+        true
+        Breed.B_GS
+            
+
+            
 let marker =
     makeSimpleSlice
         (Dna "TGTACTGACGTAGTCGTACACGTAGTCGTATCGATGTGCGACGTACTGAGCGTAGTCTGATGCGTATGCTCGTAGTAGTCGTACGTACGTGTCGTCGTGTGTGTAGTCGTGTACGAGCGTACGATCGATCAGTCTGACGTAGTGTAGTCGTAGTGTCGTAGTACGTA")
@@ -228,6 +242,7 @@ let smallInline =
         true // amplified
         Breed.B_INLINE
 
+        
 let uFooFuse = {uFoo with pragmas = uFoo.pragmas.Add(fusePragma) ; sliceName = uFoo.sliceName+"#fuse"}
 let smallInlineAmp = {smallInline with pragmas = smallInline.pragmas.Add(amp) ; sliceName = smallInline.sliceName+"#amp"}
 let smallInlineFuse = {smallInline with pragmas = smallInline.pragmas.Add(fusePragma) ; sliceName = smallInline.sliceName+"#fuse"}
@@ -239,7 +254,8 @@ let longInlineAmpFuse = {longInlineAmp with pragmas = longInlineAmp.pragmas.Add(
 let longInlineInline = {longInline with pragmas = longInline.pragmas.Add(inlinePragma)}
 let shortInlineWithRabitStart = { shortInline with pragmas = shortInline.pragmas.Add(rabitStart) ; sliceName = shortInline.sliceName+"#rabitstart"}
 let shortInlineWithRabitEnd = { shortInline with pragmas = shortInline.pragmas.Add(rabitEnd) ; sliceName = shortInline.sliceName+"#rabitend"}
-
+let oSmallInline = { oSmall with pragmas = oSmall.pragmas.Add(inlinePragma); sliceName = oSmall.sliceName+"Inline" }
+    
 let linkerAlice =
     makeSimpleSlice
         (Dna "GATCGATTAGATCGATAGGCTACG")

--- a/tests/GslCore.Tests/AssemblyTestSupport.fs
+++ b/tests/GslCore.Tests/AssemblyTestSupport.fs
@@ -143,20 +143,7 @@ let tShaz =
         true // to approx
         true // amplified
         Breed.B_TERMINATOR
-        
-let oSmall =
-    makeSimpleSlice
-        (Dna "TACTGACTGAGTCTGACTGACG")
-        "oSmall"
-        SliceType.REGULAR
-        EmptyPragmas
-        false
-        false
-        true
-        Breed.B_GS
-            
-
-            
+                    
 let marker =
     makeSimpleSlice
         (Dna "TGTACTGACGTAGTCGTACACGTAGTCGTATCGATGTGCGACGTACTGAGCGTAGTCTGATGCGTATGCTCGTAGTAGTCGTACGTACGTGTCGTCGTGTGTGTAGTCGTGTACGAGCGTACGATCGATCAGTCTGACGTAGTGTAGTCGTAGTGTCGTAGTACGTA")
@@ -167,6 +154,7 @@ let marker =
         false // to approx
         true // amplified
         Breed.B_MARKER
+        
 /// really short inline (14) which will be implemented with primers
 let shortInline =
     makeSimpleSlice
@@ -178,6 +166,18 @@ let shortInline =
         false // to approx
         true // amplified
         Breed.B_MARKER
+        
+/// really short regular (14) which will be implemented with primers        
+let shortRegular =
+    makeSimpleSlice
+        (Dna "CACATGTGGAGATT")
+        "shortRegular"
+        SliceType.REGULAR
+        EmptyPragmas
+        false
+        false
+        true
+        Breed.B_GS
 
 let rabitStart = {definition = {name = "rabitstart"; argShape = Zero; scope = PartOnly;
                      desc = "Designate part as the start of a RYSE rabit.";
@@ -241,6 +241,42 @@ let smallInline =
         false // to approx
         true // amplified
         Breed.B_INLINE
+        
+/// 102 bp regular
+let longRegular =
+    makeSimpleSlice
+        (Dna "ATGTCTCAGAACGTTTACATTGTATCGACTGCCAGAACCCCAATTGGTTCATTCCAGGGTTCTCTATCCTCCAAGACAGCAGTGGAATTGGGTGCTGTTATG")
+        "longregular"
+        SliceType.REGULAR
+        EmptyPragmas
+        false // from approx
+        false // to approx
+        true // amplified
+        Breed.B_GS
+
+/// 75 bp regular
+let mediumRegular =
+    makeSimpleSlice
+        (Dna "TTTGACGTGTAGTCGTGCGCGGTCGCGCGCGTCTATTTTTGTCGTCGTACGTACGTACGGCTAGCGTACGTACGT")
+        "mediumregular"
+        SliceType.REGULAR
+        EmptyPragmas
+        false // from approx
+        false // to approx
+        true // amplified
+        Breed.B_GS
+
+/// small 48 bp regular
+let smallRegular =
+    makeSimpleSlice
+        (Dna "TAGCTATATAGGTAGCTAGACTATCTTTATCTTACTACTTCTCTTTAT")
+        "smallregular"
+        SliceType.REGULAR
+        EmptyPragmas
+        false // from approx
+        false // to approx
+        true // amplified
+        Breed.B_GS
 
         
 let uFooFuse = {uFoo with pragmas = uFoo.pragmas.Add(fusePragma) ; sliceName = uFoo.sliceName+"#fuse"}
@@ -252,9 +288,15 @@ let mediumInlineFuse = {mediumInline with pragmas = mediumInline.pragmas.Add(fus
 let longInlineAmp = {longInline with pragmas = longInline.pragmas.Add(amp) ; sliceName = longInline.sliceName+"#amp"}
 let longInlineAmpFuse = {longInlineAmp with pragmas = longInlineAmp.pragmas.Add(fusePragma) ; sliceName = longInlineAmp.sliceName+"#fuse"}
 let longInlineInline = {longInline with pragmas = longInline.pragmas.Add(inlinePragma)}
-let shortInlineWithRabitStart = { shortInline with pragmas = shortInline.pragmas.Add(rabitStart) ; sliceName = shortInline.sliceName+"#rabitstart"}
-let shortInlineWithRabitEnd = { shortInline with pragmas = shortInline.pragmas.Add(rabitEnd) ; sliceName = shortInline.sliceName+"#rabitend"}
-let oSmallInline = { oSmall with pragmas = oSmall.pragmas.Add(inlinePragma); sliceName = oSmall.sliceName+"Inline" }
+let smallRegularInline = { smallRegular with pragmas = smallRegular.pragmas.Add(inlinePragma); sliceName = smallRegular.sliceName+"#inline"}
+let mediumRegularInline = { mediumRegular with pragmas = mediumRegular.pragmas.Add(inlinePragma); sliceName = mediumRegular.sliceName+"#inline"}
+
+let longRegularInline = { longRegular with pragmas = longRegular.pragmas.Add(inlinePragma); sliceName = longRegular.sliceName+"#inline"}
+let shortInlineWithRabitStart = { shortInline with pragmas = shortInline.pragmas.Add(rabitStart) ; sliceName = shortInline.sliceName+"#rabitstart" }
+let shortInlineWithRabitEnd = { shortInline with pragmas = shortInline.pragmas.Add(rabitEnd) ; sliceName = shortInline.sliceName+"#rabitend" }
+let shortRegularWithRabitStart = { shortRegular with pragmas = shortRegular.pragmas.Add(rabitStart) ; sliceName = shortRegular.sliceName+"#rabitstart" }
+let shortRegularWithRabitEnd = { shortRegular with pragmas = shortRegular.pragmas.Add(rabitEnd) ; sliceName = shortRegular.sliceName+"#rabitend" }
+
     
 let linkerAlice =
     makeSimpleSlice

--- a/tests/GslCore.Tests/TestMapRyseLinkers.fs
+++ b/tests/GslCore.Tests/TestMapRyseLinkers.fs
@@ -25,6 +25,11 @@ type TestMapRyseLinkers() =
         | _ -> failwith "building pragma"
     /// perform one test and check output pattern and sequences
     let runOne (name:string) isMegastitch (linkersIn:(DNASlice list*DNASlice list)) slicesIn expected =
+        
+        let cleanedSlices = slicesIn |>
+                            gslcProcess.cleanLongSlicesInPartsList pragmaTypes.EmptyPragmas |>
+                            gslcProcess.cleanShortSlicesInPartsList pragmaTypes.EmptyPragmas 
+        
         /// Boring default options
         let opts : ParsedOptions = { quiet = false
                                      refStrain = "cenpk"
@@ -47,7 +52,7 @@ type TestMapRyseLinkers() =
 
         /// Wrap up in a generic assembly
         let assemblyIn : DnaAssembly = { id = None
-                                         dnaParts = slicesIn
+                                         dnaParts = cleanedSlices
                                          name = name
                                          uri = None
                                          linkerHint =
@@ -99,6 +104,14 @@ type TestMapRyseLinkers() =
                 [uFoo ; shortInline; dFoo]
                 [linkerAlice ; uFoo ; shortInline ; dFoo ; linkerBob]
 
+    [<Test>]
+    member __.TwoPartsPlusShortGeneSliceInline() =
+        runOne "TwoPartsShortGeneSLiceInline"
+                false // is stitch
+                ([linkerAlice ; linkerBob],[]) // A and B part linkers
+                [uFoo ; oSmallInline; dFoo]
+                [linkerAlice ; uFoo ; oSmallInline ; dFoo ; linkerBob]
+                
     [<Test>]
     member __.FuseTwoNormalSlices() =
         // Note - we need to use the explicit fusionSlice here to test

--- a/tests/GslCore.Tests/TestMapRyseLinkers.fs
+++ b/tests/GslCore.Tests/TestMapRyseLinkers.fs
@@ -105,12 +105,28 @@ type TestMapRyseLinkers() =
                 [linkerAlice ; uFoo ; shortInline ; dFoo ; linkerBob]
 
     [<Test>]
-    member __.TwoPartsPlusShortGeneSliceInline() =
-        runOne "TwoPartsShortGeneSLiceInline"
+    member __.TwoPartsPlusShortRegular() =
+        runOne "TwoPartsShortRegular"
                 false // is stitch
                 ([linkerAlice ; linkerBob],[]) // A and B part linkers
-                [uFoo ; oSmallInline; dFoo]
-                [linkerAlice ; uFoo ; oSmallInline ; dFoo ; linkerBob]
+                [uFoo ; shortRegular; dFoo]
+                [linkerAlice ; uFoo ; shortRegular ; dFoo ; linkerBob]
+
+    [<Test>]
+    member __.TwoPartsPlusSmallRegularInline() =
+        runOne "TwoPartsPlusSmallRegularInline"
+                false // is stitch
+                ([linkerAlice ; linkerBob],[]) // A and B part linkers
+                [uFoo ; smallRegularInline; dFoo]
+                [linkerAlice ; uFoo ; smallRegularInline ; dFoo ; linkerBob]
+    
+    [<Test>]
+    member __.TwoPartsPlusSmallInlineAmp() =
+        runOne "TwoPartsPlusSmallInlineAmp"
+                false // is stitch
+                ([linkerAlice ; linkerBob ; linkerCharlie; linkerDoug],[]) // A and B part linkers
+                [uFoo ; smallInlineAmp; dFoo]
+                [linkerAlice ; uFoo ; linkerBob; smallInlineAmp ; linkerCharlie ; dFoo ; linkerDoug]
                 
     [<Test>]
     member __.FuseTwoNormalSlices() =
@@ -153,13 +169,22 @@ type TestMapRyseLinkers() =
                 [linkerAlice ; uFoo ; dFoo ; linkerBob ; shortInlineWithRabitStart ; oBar ; linkerDoug]
 
     [<Test>]
-    member __.``Last AMP with rabitstart + rabitend``() =
+    member __.``Last AMP with shortInline rabitstart + rabitend``() =
 
-        runOne "Last AMP with rabitstart + rabitend"
+        runOne "Last AMP with shortInline rabitstart + rabitend"
                 false // is stitch
                 ([linkerAlice ; linkerBob ; linkerCharlie ; linkerDoug],[]) // A and B part linkers
                 [ uFoo ; fuse; dFoo ; shortInlineWithRabitStart ; oBar; shortInlineWithRabitEnd]
                 [linkerAlice ; uFoo ; dFoo ; linkerBob ; shortInlineWithRabitStart ; oBar; shortInlineWithRabitEnd ; linkerDoug]
+    
+    [<Test>]
+    member __.``Last AMP with shorRegular rabitstart + rabitend``() =
+
+        runOne "Last AMP with shortInline rabitstart + rabitend"
+                false // is stitch
+                ([linkerAlice ; linkerBob ; linkerCharlie ; linkerDoug],[]) // A and B part linkers
+                [ uFoo ; fuse; dFoo ; shortRegularWithRabitStart ; oBar; shortRegularWithRabitEnd]
+                [linkerAlice ; uFoo ; dFoo ; linkerBob ; shortRegularWithRabitStart ; oBar; shortRegularWithRabitEnd ; linkerDoug]
 
 
     [<Test>]
@@ -181,6 +206,7 @@ type TestMapRyseLinkers() =
             ([linkerAlice; linkerBob;linkerCharlie; linkerDoug],[])
             [uFoo;  oBar ;fuse; uFoo ;fuse (* XXX *); shortInline; dFoo ; shortInline ; oBar ;fuse ; uFoo ; shortInlineWithRabitStart; dFoo]
             [linkerAlice ; uFoo;  linkerBob; oBar ;uFoo ;shortInline; dFoo ; shortInline ; oBar ;uFoo ; linkerCharlie; shortInlineWithRabitStart; dFoo ; linkerDoug]
+    
     [<Test>]
     member __.``inlineFusedExample3``() =
         // similar to previous case but omits fuse before shortInline


### PR DESCRIPTION
This PR contains the following:
* Enhancement to allow #inline to change regular sequences to inline, and convert short <30bp regular sequences to >
* Added error state if #inline and #amp are used together
* New tests for the enhancement